### PR TITLE
Remove Dependabot configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: pip
-    directory: '/ci'
-    schedule:
-      interval: monthly
-    ignore:
-      - dependency-name: none


### PR DESCRIPTION
- Update azure/setup-helm action to v3
- Remove the black configuration
- Add generated changelog
- Update dependency c2cciutils to v1.2.1
- Update the Renovate configuration
- Remove Dependabot configuration
