### PR TITLE
Fix type for env variable which makes no sense in schema

### DIFF
--- a/values.md
+++ b/values.md
@@ -69,6 +69,7 @@
       - **`rollingUpdate`** _(object)_: The rolling update strategy.
     - **`selector`** _(object)_: The selector of the job.
     - **`suspend`** _(boolean)_: Suspend the job.
+    - **`template`** _(boolean)_: Create the service keys in the self object.
     - **`ttlSecondsAfterFinished`** _(integer)_: The number of seconds before the job is deleted.
     - **`backoffLimit`** _(integer)_: The number of backoff limit.
     - **`podReplacementPolicy`** _(string)_: The Pod replacement policy.
@@ -164,7 +165,7 @@
         - **`name`** _(string, required)_: Name of the ConfigMap or Secret, if 'self', same name as the service.
         - **`key`** _(string, required)_: Key of the ConfigMap or Secret.
       - _object_
-        - **`type`** _(string, required)_: Free valueFrom for an environment variable. Must be one of: `["valueFrom"]`.
+        - **`type`** _(string, required)_: Free field type for an environment variable.
         - **`order`** _(integer)_: Order of the environment variable. Must be one of: `[0, 1]`. Default: `0`.
         - **`valueFrom`** _(object, required)_
 - <a id="definitions/resources"></a>**`resources`** _(object)_: [helm-common] Container: The container resources.

--- a/values.schema.json
+++ b/values.schema.json
@@ -199,8 +199,7 @@
             "properties": {
               "type": {
                 "type": "string",
-                "description": "Free valueFrom for an environment variable",
-                "enum": ["valueFrom"]
+                "description": "Free field type for an environment variable"
               },
               "order": {
                 "type": "integer",
@@ -481,6 +480,10 @@
           "suspend": {
             "type": "boolean",
             "description": "Suspend the job"
+          },
+          "template": {
+            "type": "boolean",
+            "description": "Create the service keys in the self object"
           },
           "ttlSecondsAfterFinished": {
             "type": "integer",


### PR DESCRIPTION
Schema validation was failing for this type:
```yaml
  APP_KUBERNETES_IO_INSTANCE:
    type: 'downwardAPI'
    valueFrom:
      fieldRef:
        fieldPath: "metadata.labels['app.kubernetes.io/instance']"
```

with
 
```
- services.wfs.containers.spring.env.APP_KUBERNETES_IO_INSTANCE: Must validate one and only one schema (oneOf)
- services.wfs.containers.spring.env.APP_KUBERNETES_IO_INSTANCE.type: services.wfs.containers.spring.env.APP_KUBERNETES_IO_INSTANCE.type must be one of the following: "valueFrom"
```

which makes no sense as `type` cannot be `valueFrom` which is already a dedicated field

@sbrunner  can you check that your schema generation script does not reset this manual fix please?