### PR TITLE
Adding ingressClassName field in ingress

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -8,6 +8,9 @@ metadata:
   name: {{ include "common.fullname" ( dict "root" $ "service" $.Values.ingress "serviceName" $hostGroupName ) }}
   {{- include "common.metadata" ( dict "root" $ "service" $.Values.ingress "serviceName" $hostGroupName ) | nindent 2 }}
 spec:
+{{- with $.Values.ingress.ingressClassName }}
+  ingressClassName: {{ . }}
+{{- end }}
 # Add tls only if ingress.tls.enabled is set to true and the other fields are complete.
 {{- if and ( hasKey $hostGroupDefinition "tls" ) ( eq $hostGroupDefinition.tls.enabled true ) }}
   tls:
@@ -17,8 +20,6 @@ spec:
         {{- end }}
       {{- if $hostGroupDefinition.tls.secretName }}
       secretName: {{ $hostGroupDefinition.tls.secretName }}
-      {{- else }}
-      secretName: {{ $fullName }}-{{ $hostGroupName }}
       {{- end }}
 {{- end }}
   rules:

--- a/values.md
+++ b/values.md
@@ -25,6 +25,7 @@
   - **`prefixTrunc`**: Refer to _[#/definitions/prefixTrunc](#definitions/prefixTrunc)_.
   - **`labels`**: Refer to _[#/definitions/labels](#definitions/labels)_.
   - **`annotations`**: Refer to _[#/definitions/annotations](#definitions/annotations)_.
+  - **`ingressClassName`** _(string)_: Ingress class name. Will be omitted if not specified.
   - **`hostGroups`** _(object)_: Can contain additional properties.
     - **Additional properties** _(object)_: Cannot contain additional properties.
       - **`hosts`** _(array)_

--- a/values.schema.json
+++ b/values.schema.json
@@ -339,6 +339,10 @@
         "annotations": {
           "$ref": "#/definitions/annotations"
         },
+        "ingressClassName": {
+          "type": "string",
+          "description": "Ingress class name. Will be omitted if not specified."
+        },
         "hostGroups": {
           "type": "object",
           "additionalProperties": {


### PR DESCRIPTION
- Added `ingress.ingressClassName` value.
- Removed the default value for `secretName` if the `tls` is enabled. There might be cases where a [default SSL certificate](https://kubernetes.github.io/ingress-nginx/user-guide/tls/#default-ssl-certificate) is configured in the ingress controller and there is no need to specify a secret in the ingress resource.